### PR TITLE
fix the find/replace commands on the readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,9 @@ aws ecs create-cluster \
     export EXECUTION_ROLE_ARN=$TASK_ROLE_ARN
     export AUTH=IAM # accepted values: [SASL/IAM/TLS]
 
-    docker run -i --rm -v ./Fargate:/fargate -e KAFKA_CONNECT_IMAGE_URL=$KAFKA_CONNECT_IMAGE_URL -e BROKER_ADDRESSES=$BROKER_ADDRESSES -e AWS_REGION=$AWS_REGION -e TASK_ROLE_ARN=$TASK_ROLE_ARN -e EXECUTION_ROLE_ARN=$EXECUTION_ROLE_ARN -e AUTH=$AUTH centos bash
+    docker run -i --rm -v $(pwd)/Fargate:/fargate -e KAFKA_CONNECT_IMAGE_URL=$KAFKA_CONNECT_IMAGE_URL -e BROKER_ADDRESSES=$BROKER_ADDRESSES -e AWS_REGION=$AWS_REGION -e TASK_ROLE_ARN=$TASK_ROLE_ARN -e EXECUTION_ROLE_ARN=$EXECUTION_ROLE_ARN -e AUTH=$AUTH --user root centos bash
 
-    cp ./Fargate/kafka-connect.json ./Fargate/kafka-connect.json.back
+    cp ./fargate/kafka-connect.json ./fargate/kafka-connect.json.back
 
     sed -i "s@IMAGE_URL@${KAFKA_CONNECT_IMAGE_URL}@g" ./fargate/kafka-connect.json
     sed -i "s/BROKER_ADDRESSES/${BROKER_ADDRESSES}/g" ./fargate/kafka-connect.json
@@ -221,6 +221,13 @@ aws ecs create-cluster \
     sed -i "s@TASK_ROLE_ARN@${TASK_ROLE_ARN}@g" ./fargate/kafka-connect.json
     sed -i "s@AUTH@${AUTH}@g" ./fargate/kafka-connect.json
     sed -i "s@EXECUTION_ROLE_ARN@${EXECUTION_ROLE_ARN}@g" ./fargate/kafka-connect.json
+
+    sed -i "s@IMAGE_URL@${CLICK_STREAM_PRODUCER_IMAGE_URL}@g" ./fargate/click-stream-producer.json
+    sed -i "s/BROKER_ADDRESSES/${BROKER_ADDRESSES}/g" ./fargate/click-stream-producer.json
+    sed -i "s/AWS_REGION/${AWS_REGION}/g" ./fargate/click-stream-producer.json
+    sed -i "s@TASK_ROLE_ARN@${TASK_ROLE_ARN}@g" ./fargate/click-stream-producer.json
+    sed -i "s@AUTH@${AUTH}@g" ./fargate/click-stream-producer.json
+    sed -i "s@EXECUTION_ROLE_ARN@${EXECUTION_ROLE_ARN}@g" ./fargate/click-stream-producer.json
 
     sed -i "s@IMAGE_URL@${PROMETHEUS_IMAGE_URL}@g" ./fargate/prometheus.json
     sed -i "s/AWS_REGION/${AWS_REGION}/g" ./fargate/prometheus.json

--- a/README.md
+++ b/README.md
@@ -222,13 +222,6 @@ aws ecs create-cluster \
     sed -i "s@AUTH@${AUTH}@g" ./fargate/kafka-connect.json
     sed -i "s@EXECUTION_ROLE_ARN@${EXECUTION_ROLE_ARN}@g" ./fargate/kafka-connect.json
 
-    sed -i "s@IMAGE_URL@${CLICK_STREAM_PRODUCER_IMAGE_URL}@g" ./fargate/click-stream-producer.json
-    sed -i "s/BROKER_ADDRESSES/${BROKER_ADDRESSES}/g" ./fargate/click-stream-producer.json
-    sed -i "s/AWS_REGION/${AWS_REGION}/g" ./fargate/click-stream-producer.json
-    sed -i "s@TASK_ROLE_ARN@${TASK_ROLE_ARN}@g" ./fargate/click-stream-producer.json
-    sed -i "s@AUTH@${AUTH}@g" ./fargate/click-stream-producer.json
-    sed -i "s@EXECUTION_ROLE_ARN@${EXECUTION_ROLE_ARN}@g" ./fargate/click-stream-producer.json
-
     sed -i "s@IMAGE_URL@${PROMETHEUS_IMAGE_URL}@g" ./fargate/prometheus.json
     sed -i "s/AWS_REGION/${AWS_REGION}/g" ./fargate/prometheus.json
     sed -i "s@TASK_ROLE_ARN@${TASK_ROLE_ARN}@g" ./fargate/prometheus.json


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 Docker commands for find/replace did not work previously. This update fixes the commands as per testing on Amazon Linux2 machine. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
